### PR TITLE
Implement resume/job description matching with feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # resume-jd-matcher
 
 A simple Streamlit app for uploading a resume and job description.
+The app compares your resume against the job description and
+suggests skills that could improve your match score.
 
 ## Usage
 

--- a/app.py
+++ b/app.py
@@ -1,4 +1,26 @@
+import re
+
+from PyPDF2 import PdfReader
 import streamlit as st
+
+
+def read_pdf(uploaded_file) -> str:
+    """Extract text from an uploaded PDF file."""
+    reader = PdfReader(uploaded_file)
+    text = ""
+    for page in reader.pages:
+        text += page.extract_text() or ""
+    return text
+
+
+def read_txt(uploaded_file) -> str:
+    """Read text from an uploaded text file."""
+    return uploaded_file.read().decode("utf-8")
+
+
+def tokenize(text: str) -> set[str]:
+    """Simple tokenizer that returns a set of words."""
+    return set(re.findall(r"\b[a-zA-Z]{3,}\b", text.lower()))
 
 st.title("Resume to Job Description Matcher")
 
@@ -13,3 +35,32 @@ if resume_file is not None:
 
 if description_file is not None:
     st.write("Job description uploaded:", description_file.name)
+
+if resume_file is not None and description_file is not None:
+    with st.spinner("Analyzing..."):
+        # Read resume
+        resume_text = read_pdf(resume_file)
+
+        # Read job description (PDF or txt)
+        if description_file.type == "text/plain":
+            jd_text = read_txt(description_file)
+        else:
+            jd_text = read_pdf(description_file)
+
+        resume_tokens = tokenize(resume_text)
+        jd_tokens = tokenize(jd_text)
+
+        if jd_tokens:
+            common = resume_tokens & jd_tokens
+            score = len(common) / len(jd_tokens)
+        else:
+            score = 0.0
+
+        missing_skills = sorted(jd_tokens - resume_tokens)
+
+    st.subheader("Results")
+    st.write(f"Match Score: {score:.0%}")
+
+    if missing_skills:
+        st.write("Skills to consider adding:")
+        st.write(", ".join(missing_skills[:10]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 streamlit
+PyPDF2


### PR DESCRIPTION
## Summary
- allow parsing of uploaded PDF and text files
- compute overlap between resume and job description
- show a match score and list skills missing from the resume
- document new feature in README
- add PyPDF2 dependency

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687ba8df610c83259c5dfa365cb4836d