### PR TITLE
Add text cleaning utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@ A simple Streamlit app for uploading a resume and job description.
 pip install -r requirements.txt
 streamlit run app.py
 ```
+
+## Text preprocessing
+
+A helper function `clean_text` is provided in `text_utils.py` to clean raw text by:
+
+- converting to lowercase
+- removing common English stopwords
+- stripping special characters
+
+```python
+from text_utils import clean_text
+print(clean_text("This is an Example!"))
+# output: 'example'
+```

--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 import streamlit as st
+from text_utils import clean_text
 
 st.title("Resume to Job Description Matcher")
 
-resume_file = st.file_uploader("Upload Resume (PDF)", type=["pdf"])
+resume_file = st.file_uploader("Upload Resume (PDF or Text)", type=["pdf", "txt"])
 
 description_file = st.file_uploader(
     "Upload Job Description (PDF or Text)", type=["pdf", "txt"]
@@ -10,6 +11,16 @@ description_file = st.file_uploader(
 
 if resume_file is not None:
     st.write("Resume uploaded:", resume_file.name)
+    if resume_file.type == "text/plain":
+        text = resume_file.read().decode("utf-8")
+        cleaned = clean_text(text)
+        st.subheader("Cleaned Resume Text")
+        st.write(cleaned)
 
 if description_file is not None:
     st.write("Job description uploaded:", description_file.name)
+    if description_file.type == "text/plain":
+        text = description_file.read().decode("utf-8")
+        cleaned = clean_text(text)
+        st.subheader("Cleaned Job Description")
+        st.write(cleaned)

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,0 +1,28 @@
+import re
+
+# Basic stopword list
+STOPWORDS = {
+    'a', 'an', 'the', 'and', 'or', 'for', 'nor', 'but', 'is', 'are',
+    'was', 'were', 'in', 'on', 'at', 'of', 'to', 'from', 'by', 'with',
+    'about', 'as', 'into', 'like', 'through', 'after', 'over', 'between',
+    'out', 'against', 'during', 'without', 'before', 'under', 'around',
+    'among', 'this', 'that', 'it', 'be', 'been', 'being', 'have', 'has',
+    'had', 'do', 'does', 'did', 'will', 'would', 'shall', 'should',
+    'can', 'could', 'may', 'might', 'must', 'if', 'because', 'while',
+    'where', 'when', 'who', 'whom', 'which', 'there', 'their', 'so',
+    'too', 'very'
+}
+
+
+def clean_text(text: str) -> str:
+    """Return cleaned text with stopwords and special characters removed."""
+    # Convert to lowercase
+    text = text.lower()
+    # Replace special characters with space
+    text = re.sub(r'[^a-z\s]', ' ', text)
+    # Tokenize by splitting on whitespace
+    tokens = text.split()
+    # Filter out stopwords
+    tokens = [t for t in tokens if t not in STOPWORDS]
+    # Reconstruct string
+    return ' '.join(tokens)


### PR DESCRIPTION
## Summary
- add `clean_text` helper with basic stopword removal and special character stripping
- extend Streamlit demo to show cleaned text when text files are uploaded
- document preprocessing usage in README

## Testing
- `python -m py_compile text_utils.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_687ba8b985cc8325a0f1f7306af956bf